### PR TITLE
Improve agent guidance for smaller models

### DIFF
--- a/.kiro/agents/sailor.json
+++ b/.kiro/agents/sailor.json
@@ -1,7 +1,7 @@
 {
   "name": "sailor",
   "description": "Rapid prototyping with Sailwind",
-  "prompt": "You're a designer in tech, sailing the Seas of Cheese, who can code making rapid prototypes using the Sailwind component library through the included npm package.",
+  "prompt": "You're a designer in tech, sailing the Seas of Cheese, who can code making rapid prototypes using the Sailwind component library through the included npm package.\n\nFour non-negotiable rules:\n1. Import ALL components from `@pglevy/sailwind` — never from `src/components/` or raw HTML when a Sailwind component exists.\n2. ALL SAIL prop values must be UPPERCASE (e.g. size=\"STANDARD\", not size=\"standard\").\n3. Use Lucide React icons — never emoji characters.\n4. All prototype data lives in `src/db/` as typed async functions — never inline data in page components.",
   "mcpServers": {
     "chrome-devtools": {
       "command": "npx",

--- a/.kiro/settings/mcp.json
+++ b/.kiro/settings/mcp.json
@@ -5,7 +5,7 @@
       "args": ["-y", "chrome-devtools-mcp@latest", "--no-usage-statistics"],
       "timeout": 120000,
       "connectionTimeout": 30000,
-      "disabled": false,
+      "disabled": true,
       "autoApprove": ["*"]
     },
     "playwright": {

--- a/.kiro/settings/mcp.json
+++ b/.kiro/settings/mcp.json
@@ -5,7 +5,7 @@
       "args": ["-y", "chrome-devtools-mcp@latest", "--no-usage-statistics"],
       "timeout": 120000,
       "connectionTimeout": 30000,
-      "disabled": true,
+      "disabled": false,
       "autoApprove": ["*"]
     },
     "playwright": {
@@ -13,7 +13,7 @@
       "args": ["@playwright/mcp@latest", "--browser", "chromium", "--headless"],
       "timeout": 120000,
       "connectionTimeout": 30000,
-      "disabled": false,
+      "disabled": true,
       "autoApprove": ["*"]
     }
   }

--- a/.kiro/steering/git.md
+++ b/.kiro/steering/git.md
@@ -1,5 +1,5 @@
 ---
-inclusion: always
+inclusion: manual
 ---
 
 # Git Workflow Guidance for Designers

--- a/.kiro/steering/sail-components.md
+++ b/.kiro/steering/sail-components.md
@@ -32,3 +32,4 @@ Common name mistakes to avoid:
 - ❌ `Heading` → ✅ `HeadingField`
 - ❌ `Tabs` → ✅ `TabsField`
 - ❌ `Tag` → ✅ `TagField`
+- ❌ `<UserImage />` → ✅ `<ImageField style="AVATAR" images={[{ imageType: 'user' as const, ... }]} />`

--- a/.kiro/steering/sail-props.md
+++ b/.kiro/steering/sail-props.md
@@ -1,0 +1,510 @@
+---
+inclusion: fileMatch
+fileMatchPattern: "src/pages/**"
+---
+
+# Sailwind Component Props Reference
+
+All props for every Sailwind component, parsed from the installed package. Use exact prop names and values — do not guess.
+
+**34 components** | All prop values must be UPPERCASE where the type is a SAIL enum.
+
+## Common Props (omitted from tables below)
+
+Most components accept these optional props. They are not repeated in each table:
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `className` | `string` | Additional Tailwind classes for prototype-specific styling (not part of SAIL API) |
+| `showWhen` | `boolean` | Controls component visibility |
+| `marginAbove` | `SAILMarginSize` | Space added above component |
+| `marginBelow` | `SAILMarginSize` | Space added below component |
+| `accessibilityText` | `string` | Additional text for screen readers |
+| `labelPosition` | `SAILLabelPosition` | Where the label appears (ABOVE / ADJACENT / COLLAPSED / JUSTIFIED) |
+| `helpTooltip` | `string` | Displays a help icon with tooltip text |
+| `instructions` | `string` | Supplemental text about this field |
+| `validationGroup` | `string` | Validation group name (no spaces) |
+| `requiredMessage` | `string` | Custom message when required and not provided |
+
+### ApplicationHeader
+
+| Prop | Type | Req | Description |
+|------|------|:---:|-------------|
+| `name` | `string` |  | Name of the application or object |
+| `userInitials` | `string` |  | User initials to display in avatar |
+| `showDesignerControls` | `boolean` |  | Show interface designer controls |
+| `objectType` | `ObjectType` |  | Type of object being displayed |
+| `iconSrc` | `string` |  | Path to custom icon image |
+| `previewEnabled` | `boolean` |  | Preview mode enabled |
+| `showStoriesView` | `boolean` |  | Stories view enabled |
+| `onPreviewToggle` | `(enabled: boolean) => void` |  | Callback when preview toggle changes |
+| `onStoryToggle` | `function` |  | Callback when stories toggle changes |
+| `onBackClick` | `function` |  | Callback when back button clicked |
+| `appianLogoSrc` | `string` |  | Path to Appian logo image |
+| `additionalButtons` | `Array(object)` |  | Additional buttons to display before the right-side controls |
+
+### ButtonArrayLayout
+
+| Prop | Type | Req | Description |
+|------|------|:---:|-------------|
+| `buttons` | `ButtonWidgetProps[]` | ✓ | Array of button configurations |
+| `align` | `SAILAlign` |  | Determines alignment of buttons |
+
+### ButtonWidget
+
+| Prop | Type | Req | Description |
+|------|------|:---:|-------------|
+| `label` | `string` |  | Text to display on the button |
+| `style` | `ButtonStyle` |  | Determines the button's appearance |
+| `color` | `SAILColorInput` |  | Enhancement to SAIL |
+| `size` | `SAILSize` |  | Determines size of the button |
+| `width` | `ButtonWidth` |  | Determines button width |
+| `disabled` | `boolean` |  | Prevents user from clicking the button |
+| `submit` | `boolean` |  | Whether this button submits a form |
+| `validate` | `boolean` |  | Determines whether button performs validation |
+| `confirmMessage` | `string` |  | Text for confirmation dialog |
+| `confirmHeader` | `string` |  | Text for confirmation dialog header |
+| `confirmButtonLabel` | `string` |  | Text for confirmation button |
+| `cancelButtonLabel` | `string` |  | Text for cancel button |
+| `icon` | `string` |  | Icon to display |
+| `iconPosition` | `IconPosition` |  | Position of icon |
+| `tooltip` | `string` |  | Tooltip text on hover |
+| `loadingIndicator` | `boolean` |  | Loading indicator on press |
+| `value` | `any` |  | Value associated with this button |
+| `saveInto` | `function` |  | Click handler (maps to saveInto in SAIL) |
+| `onClick` | `function` |  | Click handler (React-style alias for saveInto) |
+
+### CardLayout
+
+| Prop | Type | Req | Description |
+|------|------|:---:|-------------|
+| `children` | `ReactNode` | ✓ | Content to display inside the card |
+| `height` | `CardHeight` |  | Determines the height of the card |
+| `style` | `CardStyle / string` |  | Determines the card background color. Valid values: Any hex color (including transparency with 8 digits), or semantic values |
+| `shape` | `SAILShape` |  | Determines the border radius |
+| `padding` | `SAILPadding` |  | Determines the padding inside the card |
+| `showBorder` | `boolean` |  | Whether to show card border |
+| `showShadow` | `boolean` |  | Whether to show card shadow |
+| `borderColor` | `SAILColorInput` |  | Determines the border color. Valid values: Any hex color (including transparency), or "STANDARD" (default), "ACCENT", "POSITIVE", "WARN", "NEGATIVE" |
+| `decorativeBarPosition` | `DecorativeBarPosition` |  | Position of decorative bar |
+| `decorativeBarColor` | `SAILColorInput` |  | Color of decorative bar (hex or semantic) |
+
+### CheckboxField
+
+| Prop | Type | Req | Description |
+|------|------|:---:|-------------|
+| `label` | `string` |  | Text to display as the field label |
+| `required` | `boolean` |  | Determines if a value is required to submit the form |
+| `disabled` | `boolean` |  | Determines if the field should display as grayed out |
+| `choiceLabels` | `any[]` | ✓ | Array of options for the user to select |
+| `choiceValues` | `any[]` | ✓ | Array of values associated with the corresponding choices |
+| `value` | `any[]` |  | Values of choices to display as selected |
+| `validations` | `string[]` |  | Validation errors to display below the field |
+| `saveInto` | `(value: any[]) => void` |  | Callback when the user changes the selections |
+| `onChange` | `(value: any[]) => void` |  | Callback when the user changes the selections (React-style alias for saveInto) |
+| `align` | `SAILAlign / LEFT / CENTER / RIGHT` |  | Determines alignment of choice labels. Use with Grid Layout |
+| `choiceLayout` | `ChoiceLayout` |  | Determines the layout of choices |
+| `choiceStyle` | `ChoiceStyle` |  | Determines how choices are displayed |
+| `spacing` | `Spacing` |  | Determines space between options |
+| `data` | `any` |  | Data source (record type) - not implemented in prototype |
+| `sort` | `any[]` |  | Sort configurations - not implemented in prototype |
+| `choicePosition` | `ChoicePosition` |  | Determines whether checkboxes appear on left or right |
+
+### DialogField
+
+| Prop | Type | Req | Description |
+|------|------|:---:|-------------|
+| `open` | `boolean` |  | Whether the dialog is open |
+| `onOpenChange` | `(open: boolean) => void` |  | Callback when dialog open state changes |
+| `trigger` | `ReactNode` |  | Element that triggers the dialog (usually a button) |
+| `title` | `string` |  | Dialog title text |
+| `description` | `string` |  | Dialog description text |
+| `children` | `ReactNode` | ✓ | Main content of the dialog |
+| `width` | `DialogWidth` |  | Width of the dialog |
+| `height` | `DialogHeight` |  | Height of the dialog |
+| `showCloseButton` | `boolean` |  | Whether to show the close button |
+| `closeOnOutsideClick` | `boolean` |  | Whether clicking outside closes the dialog |
+| `closeOnEscape` | `boolean` |  | Whether pressing escape closes the dialog |
+| `onClose` | `function` |  | Callback when dialog is closed |
+
+### DocumentImage
+
+| Prop | Type | Req | Description |
+|------|------|:---:|-------------|
+| `document` | `string` | ✓ | The image file path (relative to public directory) |
+| `altText` | `string` |  | Alternate text for accessibility and screen readers |
+| `caption` | `string` |  | Optional caption text for mouseover and slideshow mode |
+| `link` | `function` |  | Link behavior when image is clicked |
+
+### DropdownField
+
+| Prop | Type | Req | Description |
+|------|------|:---:|-------------|
+| `label` | `string` |  | Text to display as the field label |
+| `required` | `boolean` |  | Determines if a value is required to submit the form |
+| `disabled` | `boolean` |  | Determines if the field should display as grayed out |
+| `choiceLabels` | `any[]` | ✓ | Array of options for the user to select |
+| `choiceValues` | `any[]` | ✓ | Array of values associated with the corresponding choices |
+| `placeholder` | `string` |  | Text to display when nothing is selected and value is null |
+| `value` | `any` |  | Value of the choice to display as selected |
+| `validations` | `string[]` |  | Validation errors to display below the field |
+| `saveInto` | `(value: any) => void` |  | Callback when the user changes the selection |
+| `onChange` | `(value: any) => void` |  | Callback when the user changes the selection (React-style alias for saveInto) |
+| `searchDisplay` | `SearchDisplay` |  | Determines when a search box displays above options |
+| `data` | `any` |  | Data source (record type) - not implemented in prototype |
+| `sort` | `any[]` |  | Sort configurations - not implemented in prototype |
+
+### FieldLabel
+
+| Prop | Type | Req | Description |
+|------|------|:---:|-------------|
+| `label` | `string` |  | The label text to display |
+| `required` | `boolean` |  | Whether the field is required (shows asterisk) |
+| `htmlFor` | `string` |  | HTML for attribute to associate label with input |
+
+### FieldWrapper
+
+| Prop | Type | Req | Description |
+|------|------|:---:|-------------|
+| `label` | `string` |  | The label text to display |
+| `required` | `boolean` |  | Whether the field is required (shows asterisk) |
+| `inputId` | `string` | ✓ | HTML ID for the input element (for label association) |
+| `children` | `ReactNode` | ✓ | The input/control element to render |
+| `footer` | `ReactNode` |  | Optional additional content below instructions (validation errors, etc.) |
+
+### GridColumn
+
+| Prop | Type | Req | Description |
+|------|------|:---:|-------------|
+| `label` | `string` |  | Text to display as the column header |
+| `sortField` | `string` |  | Field name used for sorting when this column header is clicked |
+| `value` | `string / ((row: any, index: number) => ReactNode)` |  | Display value for each cell. Can be: - A string field name to look up on each row object - A function (row: any, index: number) => React.ReactNode / |
+| `align` | `SAILAlign` |  | Alignment for header and cell content |
+| `width` | `SAILGridColumnWidth` |  | Column width |
+| `backgroundColor` | `SAILColorInput / ((row: any) => string)` |  | Background color for cells — hex color or semantic name |
+
+### HeadingField
+
+| Prop | Type | Req | Description |
+|------|------|:---:|-------------|
+| `text` | `string` | ✓ | Text to display in the header |
+| `size` | `HeadingSize` |  | Determines the text size |
+| `headingTag` | `HeadingTag` |  | Determines the heading tag for screen readers |
+| `color` | `SAILColorInput` |  | Determines the label color - hex color, semantic color, or palette token (e.g. TEAL_700) |
+| `fontWeight` | `FontWeight` |  | Determines the thickness of the text |
+| `link` | `function` |  | Link to apply to the text (simplified - accepts onClick handler) |
+| `align` | `SAILAlign` |  | Determines alignment of the text |
+| `preventWrapping` | `boolean` |  | Prevents wrapping to multiple lines when true |
+
+### Icon
+
+| Prop | Type | Req | Description |
+|------|------|:---:|-------------|
+| `icon` | `string` | ✓ | The key of the icon to display |
+| `altText` | `string` |  | Alternative text for accessibility |
+| `caption` | `string` |  | Text to display on mouseover |
+| `size` | `SAILSizeExtended` |  | Icon size |
+| `color` | `SAILColorInput` |  | Icon color - semantic color, palette token (e.g. TEAL_700), or hex value |
+| `link` | `function` |  | Link behavior when icon is clicked |
+| `linkStyle` | `LinkStyle` |  | How the link is underlined |
+
+### ImageField
+
+| Prop | Type | Req | Description |
+|------|------|:---:|-------------|
+| `label` | `string` |  | Text to display as the field label |
+| `images` | `ImageFieldImage[]` | ✓ | Array of images to display (supports both document and user images) |
+| `size` | `ImageSize` |  | Determines how the images are sized |
+| `isThumbnail` | `boolean` |  | Determines whether images can be viewed larger when clicked |
+| `style` | `ImageStyle` |  | Determines how the images are rendered |
+| `align` | `SAILAlign` |  | Determines alignment of the images |
+
+### MessageBanner
+
+| Prop | Type | Req | Description |
+|------|------|:---:|-------------|
+| `primaryText` | `string` |  | Text to display on the first line inside the banner |
+| `secondaryText` | `string` |  | Text to display beneath the primary text inside the banner |
+| `backgroundColor` | `BackgroundColor` |  | Background color - semantic values or hex color (with optional transparency) |
+| `highlightColor` | `HighlightColor` |  | Color of the decorative bar and icon - semantic values or hex color |
+| `icon` | `info / success / warning / error` |  | Icon to display before the primary text (decorative only) |
+| `showDecorativeBar` | `boolean` |  | Whether to show the decorative bar |
+| `shape` | `SAILShape` |  | Banner shape |
+| `announceBehavior` | `AnnounceBehavior` |  | Screen reader behavior for announcing banner text |
+| `buttons` | `ButtonWidgetProps[]` |  | Optional buttons to display to the right of the content |
+| `buttonsAlign` | `SAILAlign` |  | Alignment of the optional buttons |
+| `showCloseButton` | `boolean` |  | Whether to show a close button in the upper right |
+| `onClose` | `function` |  | Callback when the close button is clicked |
+
+### MilestoneField
+
+| Prop | Type | Req | Description |
+|------|------|:---:|-------------|
+| `label` | `string` |  | Text to display as the field label |
+| `steps` | `string[]` | ✓ | Array of labels describing the sequence of steps |
+| `links` | `any[]` |  | Array of links to apply to the steps |
+| `active` | `number / null` |  | Index of the current step. When null, all steps are future. When -1, all steps are completed |
+| `orientation` | `Orientation` |  | Determines the layout of the milestone steps |
+| `color` | `Color` |  | Determines the fill color |
+| `stepStyle` | `StepStyle` |  | Determines the style of the milestone steps |
+
+### MultipleDropdownField
+
+| Prop | Type | Req | Description |
+|------|------|:---:|-------------|
+| `label` | `string` |  | Text to display as the field label |
+| `required` | `boolean` |  | Determines if a value is required to submit the form |
+| `disabled` | `boolean` |  | Determines if the field should display as grayed out |
+| `placeholder` | `string` |  | Text to display in the field when it is empty |
+| `choiceLabels` | `any[]` | ✓ | Array of options for the user to select |
+| `choiceValues` | `any[]` | ✓ | Array of values associated with the corresponding choices |
+| `value` | `any[]` |  | Values of choices to display as selected |
+| `validations` | `string[]` |  | Validation errors to display below the field |
+| `saveInto` | `(value: any[] / null) => void` |  | Callback when the user changes the selections |
+| `onChange` | `(value: any[] / null) => void` |  | Callback when the user changes the selections (React-style alias for saveInto) |
+| `searchDisplay` | `SearchDisplay` |  | Determines when a search box displays above options |
+| `data` | `any` |  | Data source (record type) - not implemented in prototype |
+| `sort` | `any[]` |  | Sort configurations - not implemented in prototype |
+
+### ProgressBar
+
+| Prop | Type | Req | Description |
+|------|------|:---:|-------------|
+| `label` | `string` |  | Text to display as the field label |
+| `percentage` | `number` | ✓ | Number to display between 0 and 100 |
+| `color` | `ProgressBarColor` |  | Progress bar color - semantic values or hex color |
+| `style` | `ProgressBarStyle` |  | Thickness of the progress bar |
+| `showPercentage` | `boolean` |  | Whether to display the percentage text |
+
+### RadioButtonField
+
+| Prop | Type | Req | Description |
+|------|------|:---:|-------------|
+| `label` | `string` |  | Text to display as the field label |
+| `required` | `boolean` |  | Determines if a value is required to submit the form |
+| `disabled` | `boolean` |  | Determines if the field should display as grayed out |
+| `choiceLabels` | `any[]` | ✓ | Array of options for the user to select |
+| `choiceValues` | `any[]` | ✓ | Array of values associated with the corresponding choices |
+| `value` | `any` |  | Value of choice to display as selected |
+| `validations` | `string[]` |  | Validation errors to display below the field |
+| `saveInto` | `(value: any) => void` |  | Callback when the user changes the selection |
+| `onChange` | `(value: any) => void` |  | Callback when the user changes the selection (React-style alias for saveInto) |
+| `choiceLayout` | `ChoiceLayout` |  | Determines the layout of choices |
+| `choiceStyle` | `ChoiceStyle` |  | Determines how choices are displayed |
+| `spacing` | `Spacing` |  | Determines space between options |
+| `data` | `any` |  | Data source (record type) - not implemented in prototype |
+| `sort` | `any[]` |  | Sort configurations - not implemented in prototype |
+| `choicePosition` | `ChoicePosition` |  | Determines whether radio buttons appear on left or right |
+
+### ReadOnlyGrid
+
+| Prop | Type | Req | Description |
+|------|------|:---:|-------------|
+| `label` | `string` |  | Text to display as the grid label |
+| `emptyGridMessage` | `string` |  | Text to display when no data is available |
+| `data` | `Record[]` |  | The data array to display |
+| `children` | `ReactNode` |  | GridColumn children defining the columns |
+| `pageSize` | `number` |  | Maximum rows per page. Default: 10 |
+| `initialSorts` | `SortInfo[]` |  | Initial sort configurations |
+| `selectable` | `boolean` |  | Whether rows are selectable |
+| `selectionStyle` | `CHECKBOX / ROW_HIGHLIGHT` |  | Selection visual style |
+| `selectionValue` | `(string / number)[]` |  | Currently selected row identifiers |
+| `selectionSaveInto` | `(selectedIds: (string / number)[]) => void` |  | Callback when selection changes |
+| `validations` | `string[]` |  | Validation messages to display below the grid |
+| `spacing` | `STANDARD / DENSE` |  | Cell spacing |
+| `height` | `SAILGridHeight` |  | Grid height |
+| `borderStyle` | `STANDARD / LIGHT` |  | Border style |
+| `shadeAlternateRows` | `boolean` |  | Whether to shade alternate rows |
+| `rowHeader` | `number` |  | Index of column to use as row header for accessibility |
+
+### RecordView
+
+| Prop | Type | Req | Description |
+|------|------|:---:|-------------|
+| `displayName` | `string` |  | Site/solution display name |
+| `pages` | `SiteNavPage[]` | ✓ | Site pages for the left nav |
+| `collapsed` | `boolean` |  | Controlled collapsed state |
+| `onCollapseToggle` | `(collapsed: boolean) => void` |  | Collapse toggle callback |
+| `userName` | `string` |  | User full name |
+| `appianLogoSrc` | `string` |  | Appian logo path |
+| `highlightColor` | `SAILSemanticColor / string` |  | Highlight color for selected nav item (passed to SiteNav) |
+| `recordTitle` | `string` | ✓ | Record title (e.g. "REC-001 \| Sample Record") |
+| `recordActions` | `RecordAction[]` |  | Record action buttons shown in the record header. First 3 are shown as buttons; extras appear in an overflow dropdown. |
+| `views` | `RecordViewTab[]` |  | Record view tabs |
+| `selectedViewIndex` | `number` |  | Index of the currently selected view (controlled). When provided, overrides isSelected on individual tabs. |
+| `onViewChange` | `(index: number) => void` |  | Callback when a view tab is clicked. Receives the index of the clicked tab. |
+| `children` | `ReactNode` |  | Content to render inside the active view area. This is the slot UXDs fill in. |
+
+### RichTextDisplayField
+
+| Prop | Type | Req | Description |
+|------|------|:---:|-------------|
+| `label` | `string` |  | Text to display as the field label |
+| `align` | `TextAlign` |  | Alignment of the text value |
+| `value` | `ReactNode[]` |  | Array of rich text to display |
+| `preventWrapping` | `boolean` |  | Prevents wrapping to multiple lines |
+| `tooltip` | `string` |  | Tooltip text on mouseover |
+
+### SideNavAdmin
+
+| Prop | Type | Req | Description |
+|------|------|:---:|-------------|
+| `sections` | `NavSection[]` |  | Navigation sections with headings and items |
+| `activeItem` | `string` |  | Label of the currently active/selected item |
+| `onItemClick` | `(label: string) => void` |  | Callback when a nav item is clicked |
+
+### SiteNav
+
+| Prop | Type | Req | Description |
+|------|------|:---:|-------------|
+| `displayName` | `string` |  | Site/solution display name (maps to NavigationLayout.displayName) |
+| `pages` | `SiteNavPage[]` | ✓ | Array of site pages (maps to NavigationLayout.tabs / NavigationNode[]) |
+| `collapsed` | `boolean` |  | Controlled collapsed state |
+| `onCollapseToggle` | `(collapsed: boolean) => void` |  | Callback when collapse toggle is clicked |
+| `showNavigation` | `boolean` |  | Whether to show the navigation (maps to NavigationLayout.showNavigation) |
+| `userName` | `string` |  | User full name — initials are derived automatically |
+| `appianLogoSrc` | `string` |  | Path to Appian logo image |
+| `highlightColor` | `SAILSemanticColor / string` |  | Background color for the selected/highlighted page. Accepts hex or semantic color. Default: "POSITIVE" |
+
+### SliderField
+
+| Prop | Type | Req | Description |
+|------|------|:---:|-------------|
+| `label` | `string` |  | Text to display as the field label |
+| `required` | `boolean` |  | Determines if a value is required to submit the form |
+| `disabled` | `boolean` |  | Determines if the field should display as grayed out |
+| `value` | `number / number[]` |  | Current value(s) - single number for single slider, array for range |
+| `min` | `number` |  | Minimum value |
+| `max` | `number` |  | Maximum value |
+| `step` | `number` |  | Step increment |
+| `validations` | `string[]` |  | Validation errors to display below the field |
+| `saveInto` | `(value: number / number[]) => void` |  | Callback when the user changes the slider value |
+| `onChange` | `(value: number / number[]) => void` |  | Callback when the user changes the slider value (React-style alias for saveInto) |
+| `size` | `SAILSize` |  | Size of the slider |
+| `color` | `ACCENT / POSITIVE / NEGATIVE / SECONDARY / SAILColorInput` |  | Color of the slider track and thumb (hex or semantic) |
+| `orientation` | `SliderOrientation` |  | Orientation of the slider |
+| `showValue` | `boolean` |  | Show current value(s) as text |
+| `formatValue` | `(value: number) => string` |  | Custom formatter for displayed values |
+
+### StampField
+
+| Prop | Type | Req | Description |
+|------|------|:---:|-------------|
+| `label` | `string` |  | Text to display as the field label |
+| `icon` | `string` |  | Icon to display inside the stamp |
+| `text` | `string` |  | Text to display within the stamp |
+| `backgroundColor` | `StampBackgroundColor` |  | Determines the background color |
+| `contentColor` | `StampContentColor` |  | Determines the icon color |
+| `size` | `StampSize` |  | Determines the size of the stamp |
+| `align` | `SAILAlign` |  | Determines alignment of the stamp |
+| `tooltip` | `string` |  | Text to display on mouseover (web) or tap (mobile) |
+| `link` | `any` |  | Link to apply to the stamp |
+| `shape` | `SAILShape` |  | Determines the stamp shape |
+
+### SwitchField
+
+| Prop | Type | Req | Description |
+|------|------|:---:|-------------|
+| `label` | `string` |  | Text to display as the field label |
+| `required` | `boolean` |  | Determines if a value is required to submit the form |
+| `disabled` | `boolean` |  | Determines if the field should display as grayed out |
+| `value` | `boolean` |  | Current checked state (true = on, false = off) |
+| `validations` | `string[]` |  | Validation errors to display below the field |
+| `saveInto` | `(value: boolean) => void` |  | Callback when the user toggles the switch |
+| `onChange` | `(value: boolean) => void` |  | Callback when the user toggles the switch (React-style alias for saveInto) |
+| `size` | `SAILSize` |  | Size of the switch and its label |
+| `color` | `ACCENT / POSITIVE / NEGATIVE / SECONDARY / STANDARD / SAILColorInput` |  | Color when switch is on (hex or semantic) |
+| `switchLabelPosition` | `LEFT / RIGHT` |  | Position of the inline label relative to the switch control: LEFT or RIGHT |
+
+### TabsField
+
+| Prop | Type | Req | Description |
+|------|------|:---:|-------------|
+| `tabs` | `TabItem[]` | ✓ | Array of tab configurations |
+| `value` | `string` |  | Currently active tab value (controlled) |
+| `defaultValue` | `string` |  | Default active tab value (uncontrolled) |
+| `onValueChange` | `(value: string) => void` |  | Callback when active tab changes |
+| `variant` | `TabsVariant` |  | Visual variant for tab styling |
+| `orientation` | `HORIZONTAL / VERTICAL` |  | Orientation of the tabs (only applies to UNDERLINE variant) |
+| `size` | `SAILSize` |  | Size of the tab triggers |
+| `loop` | `boolean` |  | Whether tabs should loop when navigating with keyboard |
+| `color` | `ACCENT / POSITIVE / NEGATIVE / SECONDARY / SAILColorInput` |  | Color scheme for active tabs (hex or semantic) |
+| `activationMode` | `AUTOMATIC / MANUAL` |  | Activation mode - whether tabs activate on focus or click |
+
+### TagField
+
+| Prop | Type | Req | Description |
+|------|------|:---:|-------------|
+| `tags` | `TagItemProps[]` | ✓ | Array of tag items to display |
+| `label` | `string` |  | Text to display as the field label |
+| `align` | `SAILAlign` |  | Determines alignment of tags |
+| `size` | `TagSize` |  | Size of the tags |
+
+### TagItem
+
+| Prop | Type | Req | Description |
+|------|------|:---:|-------------|
+| `text` | `string` | ✓ | Text to display within the tag (max 40 characters in SAIL) |
+| `backgroundColor` | `SAILColorInput` |  | Background color - hex value, semantic color, or palette token (e.g. TEAL_700) |
+| `textColor` | `SAILColorInput` |  | Text color - hex value, semantic color, palette token, or "STANDARD" |
+| `tooltip` | `string` |  | Tooltip text to display on hover |
+| `link` | `string` |  | Link to apply to the tag (href string for React implementation) |
+
+### TextField
+
+| Prop | Type | Req | Description |
+|------|------|:---:|-------------|
+| `label` | `string` |  | Text to display as the field label |
+| `required` | `boolean` |  | Determines if a value is required to submit the form |
+| `readOnly` | `boolean` |  | Determines if the field should display as not editable |
+| `disabled` | `boolean` |  | Determines if the field should display as potentially editable but grayed out |
+| `value` | `string` |  | Text to display in the text field |
+| `validations` | `string[]` |  | Validation errors to display below the field when the value is not null |
+| `saveInto` | `(value: string) => void` |  | Callback when the user changes the text |
+| `onChange` | `(value: string) => void` |  | Callback when the user changes the text (React-style alias for saveInto) |
+| `refreshAfter` | `RefreshAfter` |  | Determines when the interface is refreshed with the saved value |
+| `align` | `TextAlign` |  | Determines alignment of the text value |
+| `placeholder` | `string` |  | Text to display in the field when it is empty |
+| `masked` | `boolean` |  | Determines if the value is obscured from view (password field) |
+| `inputPurpose` | `InputPurpose` |  | Indicates the intent of input for accessibility improvements |
+| `characterLimit` | `number` |  | Determines the maximum number of characters |
+| `showCharacterCount` | `boolean` |  | Determines if the character count displays on the text field |
+
+### TextItem
+
+| Prop | Type | Req | Description |
+|------|------|:---:|-------------|
+| `text` | `string / ReactNode / (string / ReactNode)[]` | ✓ | Array of text to display as a rich text item |
+| `style` | `TextStyle / TextStyle[]` |  | Text style(s) to apply. Multiple styles may be applied |
+| `size` | `SAILSizeExtended` |  | Text size |
+| `color` | `SAILColorInput` |  | Text color - semantic color, palette token (e.g. TEAL_700), or hex value |
+| `link` | `function` |  | Link to apply to the text |
+| `linkStyle` | `LinkStyle` |  | How the link is underlined |
+
+### ToggleField
+
+| Prop | Type | Req | Description |
+|------|------|:---:|-------------|
+| `label` | `string` |  | Text to display as the field label |
+| `text` | `string` |  | Text to display on the toggle button |
+| `required` | `boolean` |  | Determines if a value is required to submit the form |
+| `disabled` | `boolean` |  | Determines if the field should display as grayed out |
+| `value` | `boolean` |  | Current pressed state (true = pressed, false = unpressed) |
+| `validations` | `string[]` |  | Validation errors to display below the field |
+| `saveInto` | `(value: boolean) => void` |  | Callback when the user toggles the button |
+| `onChange` | `(value: boolean) => void` |  | Callback when the user toggles the button (React-style alias for saveInto) |
+| `size` | `SAILSize` |  | Size of the toggle button |
+| `color` | `ACCENT / POSITIVE / NEGATIVE / SECONDARY / STANDARD / SAILColorInput` |  | Color when toggle is pressed (hex or semantic) |
+| `style` | `ToggleStyle` |  | Determines the button's appearance |
+| `icon` | `string` |  | Icon to display in the button |
+| `iconPosition` | `START / END` |  | Position of icon relative to text |
+
+### UserImage
+
+| Prop | Type | Req | Description |
+|------|------|:---:|-------------|
+| `imageType` | `'user'` | ✓ | Discriminator to identify this as a user image |
+| `user` | `User` |  | The user whose profile photo will be shown |
+| `altText` | `string` |  | Alternate text for accessibility and screen readers |
+| `caption` | `string` |  | Optional caption text for mouseover (tooltip) |
+| `link` | `function` |  | Link behavior when image is clicked |

--- a/.kiro/steering/sail-props.md
+++ b/.kiro/steering/sail-props.md
@@ -33,7 +33,7 @@ Most components accept these optional props. They are not repeated in each table
 | `name` | `string` |  | Name of the application or object |
 | `userInitials` | `string` |  | User initials to display in avatar |
 | `showDesignerControls` | `boolean` |  | Show interface designer controls |
-| `objectType` | `ObjectType` |  | Type of object being displayed |
+| `objectType` | `'app' / 'interface' / 'record-type' / 'expression-rule'` |  | Type of object being displayed |
 | `iconSrc` | `string` |  | Path to custom icon image |
 | `previewEnabled` | `boolean` |  | Preview mode enabled |
 | `showStoriesView` | `boolean` |  | Stories view enabled |
@@ -55,10 +55,10 @@ Most components accept these optional props. They are not repeated in each table
 | Prop | Type | Req | Description |
 |------|------|:---:|-------------|
 | `label` | `string` |  | Text to display on the button |
-| `style` | `ButtonStyle` |  | Determines the button's appearance |
+| `style` | `SOLID / OUTLINE / GHOST / LINK` |  | Determines the button's appearance |
 | `color` | `SAILColorInput` |  | Enhancement to SAIL |
 | `size` | `SAILSize` |  | Determines size of the button |
-| `width` | `ButtonWidth` |  | Determines button width |
+| `width` | `MINIMIZE / FILL` |  | Determines button width |
 | `disabled` | `boolean` |  | Prevents user from clicking the button |
 | `submit` | `boolean` |  | Whether this button submits a form |
 | `validate` | `boolean` |  | Determines whether button performs validation |
@@ -67,7 +67,7 @@ Most components accept these optional props. They are not repeated in each table
 | `confirmButtonLabel` | `string` |  | Text for confirmation button |
 | `cancelButtonLabel` | `string` |  | Text for cancel button |
 | `icon` | `string` |  | Icon to display |
-| `iconPosition` | `IconPosition` |  | Position of icon |
+| `iconPosition` | `START / END` |  | Position of icon |
 | `tooltip` | `string` |  | Tooltip text on hover |
 | `loadingIndicator` | `boolean` |  | Loading indicator on press |
 | `value` | `any` |  | Value associated with this button |
@@ -79,14 +79,14 @@ Most components accept these optional props. They are not repeated in each table
 | Prop | Type | Req | Description |
 |------|------|:---:|-------------|
 | `children` | `ReactNode` | ✓ | Content to display inside the card |
-| `height` | `CardHeight` |  | Determines the height of the card |
-| `style` | `CardStyle / string` |  | Determines the card background color. Valid values: Any hex color (including transparency with 8 digits), or semantic values |
+| `height` | `AUTO / SHORT / MEDIUM / TALL / EXTRA_TALL` |  | Determines the height of the card |
+| `style` | `NONE / TRANSPARENT / STANDARD / ACCENT / SUCCESS / WARN / ERROR / INFO / CHARCOAL_SCHEME / NAVY_SCHEME / PLUM_SCHEME / string` |  | Determines the card background color. Valid values: Any hex color (including transparency with 8 digits), or semantic values |
 | `shape` | `SAILShape` |  | Determines the border radius |
 | `padding` | `SAILPadding` |  | Determines the padding inside the card |
 | `showBorder` | `boolean` |  | Whether to show card border |
 | `showShadow` | `boolean` |  | Whether to show card shadow |
 | `borderColor` | `SAILColorInput` |  | Determines the border color. Valid values: Any hex color (including transparency), or "STANDARD" (default), "ACCENT", "POSITIVE", "WARN", "NEGATIVE" |
-| `decorativeBarPosition` | `DecorativeBarPosition` |  | Position of decorative bar |
+| `decorativeBarPosition` | `TOP / START / NONE` |  | Position of decorative bar |
 | `decorativeBarColor` | `SAILColorInput` |  | Color of decorative bar (hex or semantic) |
 
 ### CheckboxField
@@ -103,12 +103,12 @@ Most components accept these optional props. They are not repeated in each table
 | `saveInto` | `(value: any[]) => void` |  | Callback when the user changes the selections |
 | `onChange` | `(value: any[]) => void` |  | Callback when the user changes the selections (React-style alias for saveInto) |
 | `align` | `SAILAlign / LEFT / CENTER / RIGHT` |  | Determines alignment of choice labels. Use with Grid Layout |
-| `choiceLayout` | `ChoiceLayout` |  | Determines the layout of choices |
-| `choiceStyle` | `ChoiceStyle` |  | Determines how choices are displayed |
-| `spacing` | `Spacing` |  | Determines space between options |
+| `choiceLayout` | `STACKED / COMPACT` |  | Determines the layout of choices |
+| `choiceStyle` | `STANDARD / CARDS` |  | Determines how choices are displayed |
+| `spacing` | `STANDARD / MORE / EVEN_MORE` |  | Determines space between options |
 | `data` | `any` |  | Data source (record type) - not implemented in prototype |
 | `sort` | `any[]` |  | Sort configurations - not implemented in prototype |
-| `choicePosition` | `ChoicePosition` |  | Determines whether checkboxes appear on left or right |
+| `choicePosition` | `START / END` |  | Determines whether checkboxes appear on left or right |
 
 ### DialogField
 
@@ -150,7 +150,7 @@ Most components accept these optional props. They are not repeated in each table
 | `validations` | `string[]` |  | Validation errors to display below the field |
 | `saveInto` | `(value: any) => void` |  | Callback when the user changes the selection |
 | `onChange` | `(value: any) => void` |  | Callback when the user changes the selection (React-style alias for saveInto) |
-| `searchDisplay` | `SearchDisplay` |  | Determines when a search box displays above options |
+| `searchDisplay` | `AUTO / ON / OFF` |  | Determines when a search box displays above options |
 | `data` | `any` |  | Data source (record type) - not implemented in prototype |
 | `sort` | `any[]` |  | Sort configurations - not implemented in prototype |
 
@@ -188,10 +188,10 @@ Most components accept these optional props. They are not repeated in each table
 | Prop | Type | Req | Description |
 |------|------|:---:|-------------|
 | `text` | `string` | ✓ | Text to display in the header |
-| `size` | `HeadingSize` |  | Determines the text size |
-| `headingTag` | `HeadingTag` |  | Determines the heading tag for screen readers |
+| `size` | `EXTRA_SMALL / SMALL / MEDIUM / MEDIUM_PLUS / LARGE / LARGE_PLUS` |  | Determines the text size |
+| `headingTag` | `H1 / H2 / H3 / H4 / H5 / H6` |  | Determines the heading tag for screen readers |
 | `color` | `SAILColorInput` |  | Determines the label color - hex color, semantic color, or palette token (e.g. TEAL_700) |
-| `fontWeight` | `FontWeight` |  | Determines the thickness of the text |
+| `fontWeight` | `LIGHT / REGULAR / SEMI_BOLD / BOLD` |  | Determines the thickness of the text |
 | `link` | `function` |  | Link to apply to the text (simplified - accepts onClick handler) |
 | `align` | `SAILAlign` |  | Determines alignment of the text |
 | `preventWrapping` | `boolean` |  | Prevents wrapping to multiple lines when true |
@@ -206,17 +206,17 @@ Most components accept these optional props. They are not repeated in each table
 | `size` | `SAILSizeExtended` |  | Icon size |
 | `color` | `SAILColorInput` |  | Icon color - semantic color, palette token (e.g. TEAL_700), or hex value |
 | `link` | `function` |  | Link behavior when icon is clicked |
-| `linkStyle` | `LinkStyle` |  | How the link is underlined |
+| `linkStyle` | `INLINE / STANDALONE` |  | How the link is underlined |
 
 ### ImageField
 
 | Prop | Type | Req | Description |
 |------|------|:---:|-------------|
 | `label` | `string` |  | Text to display as the field label |
-| `images` | `ImageFieldImage[]` | ✓ | Array of images to display (supports both document and user images) |
-| `size` | `ImageSize` |  | Determines how the images are sized |
+| `images` | `DocumentImageProps / UserImageProps[]` | ✓ | Array of images to display (supports both document and user images) |
+| `size` | `ICON / ICON_PLUS / TINY / EXTRA_SMALL / SMALL / SMALL_PLUS / MEDIUM / MEDIUM_PLUS / LARGE / LARGE_PLUS / EXTRA_LARGE / FIT / GALLERY` |  | Determines how the images are sized |
 | `isThumbnail` | `boolean` |  | Determines whether images can be viewed larger when clicked |
-| `style` | `ImageStyle` |  | Determines how the images are rendered |
+| `style` | `STANDARD / AVATAR` |  | Determines how the images are rendered |
 | `align` | `SAILAlign` |  | Determines alignment of the images |
 
 ### MessageBanner
@@ -244,9 +244,9 @@ Most components accept these optional props. They are not repeated in each table
 | `steps` | `string[]` | ✓ | Array of labels describing the sequence of steps |
 | `links` | `any[]` |  | Array of links to apply to the steps |
 | `active` | `number / null` |  | Index of the current step. When null, all steps are future. When -1, all steps are completed |
-| `orientation` | `Orientation` |  | Determines the layout of the milestone steps |
-| `color` | `Color` |  | Determines the fill color |
-| `stepStyle` | `StepStyle` |  | Determines the style of the milestone steps |
+| `orientation` | `HORIZONTAL / VERTICAL` |  | Determines the layout of the milestone steps |
+| `color` | `ACCENT / POSITIVE / NEGATIVE / WARN / SAILColorInput` |  | Determines the fill color |
+| `stepStyle` | `LINE / CHEVRON / DOT` |  | Determines the style of the milestone steps |
 
 ### MultipleDropdownField
 
@@ -262,7 +262,7 @@ Most components accept these optional props. They are not repeated in each table
 | `validations` | `string[]` |  | Validation errors to display below the field |
 | `saveInto` | `(value: any[] / null) => void` |  | Callback when the user changes the selections |
 | `onChange` | `(value: any[] / null) => void` |  | Callback when the user changes the selections (React-style alias for saveInto) |
-| `searchDisplay` | `SearchDisplay` |  | Determines when a search box displays above options |
+| `searchDisplay` | `AUTO / ON / OFF` |  | Determines when a search box displays above options |
 | `data` | `any` |  | Data source (record type) - not implemented in prototype |
 | `sort` | `any[]` |  | Sort configurations - not implemented in prototype |
 
@@ -289,12 +289,12 @@ Most components accept these optional props. They are not repeated in each table
 | `validations` | `string[]` |  | Validation errors to display below the field |
 | `saveInto` | `(value: any) => void` |  | Callback when the user changes the selection |
 | `onChange` | `(value: any) => void` |  | Callback when the user changes the selection (React-style alias for saveInto) |
-| `choiceLayout` | `ChoiceLayout` |  | Determines the layout of choices |
-| `choiceStyle` | `ChoiceStyle` |  | Determines how choices are displayed |
-| `spacing` | `Spacing` |  | Determines space between options |
+| `choiceLayout` | `STACKED / COMPACT` |  | Determines the layout of choices |
+| `choiceStyle` | `STANDARD / CARDS` |  | Determines how choices are displayed |
+| `spacing` | `STANDARD / MORE / EVEN_MORE` |  | Determines space between options |
 | `data` | `any` |  | Data source (record type) - not implemented in prototype |
 | `sort` | `any[]` |  | Sort configurations - not implemented in prototype |
-| `choicePosition` | `ChoicePosition` |  | Determines whether radio buttons appear on left or right |
+| `choicePosition` | `START / END` |  | Determines whether radio buttons appear on left or right |
 
 ### ReadOnlyGrid
 
@@ -340,7 +340,7 @@ Most components accept these optional props. They are not repeated in each table
 | Prop | Type | Req | Description |
 |------|------|:---:|-------------|
 | `label` | `string` |  | Text to display as the field label |
-| `align` | `TextAlign` |  | Alignment of the text value |
+| `align` | `LEFT / CENTER / RIGHT` |  | Alignment of the text value |
 | `value` | `ReactNode[]` |  | Array of rich text to display |
 | `preventWrapping` | `boolean` |  | Prevents wrapping to multiple lines |
 | `tooltip` | `string` |  | Tooltip text on mouseover |
@@ -382,7 +382,7 @@ Most components accept these optional props. They are not repeated in each table
 | `onChange` | `(value: number / number[]) => void` |  | Callback when the user changes the slider value (React-style alias for saveInto) |
 | `size` | `SAILSize` |  | Size of the slider |
 | `color` | `ACCENT / POSITIVE / NEGATIVE / SECONDARY / SAILColorInput` |  | Color of the slider track and thumb (hex or semantic) |
-| `orientation` | `SliderOrientation` |  | Orientation of the slider |
+| `orientation` | `HORIZONTAL / VERTICAL` |  | Orientation of the slider |
 | `showValue` | `boolean` |  | Show current value(s) as text |
 | `formatValue` | `(value: number) => string` |  | Custom formatter for displayed values |
 
@@ -393,9 +393,9 @@ Most components accept these optional props. They are not repeated in each table
 | `label` | `string` |  | Text to display as the field label |
 | `icon` | `string` |  | Icon to display inside the stamp |
 | `text` | `string` |  | Text to display within the stamp |
-| `backgroundColor` | `StampBackgroundColor` |  | Determines the background color |
-| `contentColor` | `StampContentColor` |  | Determines the icon color |
-| `size` | `StampSize` |  | Determines the size of the stamp |
+| `backgroundColor` | `SAILColorInput / TRANSPARENT` |  | Determines the background color |
+| `contentColor` | `SAILColorInput` |  | Determines the icon color |
+| `size` | `TINY / SMALL / MEDIUM / LARGE` |  | Determines the size of the stamp |
 | `align` | `SAILAlign` |  | Determines alignment of the stamp |
 | `tooltip` | `string` |  | Text to display on mouseover (web) or tap (mobile) |
 | `link` | `any` |  | Link to apply to the stamp |
@@ -438,7 +438,7 @@ Most components accept these optional props. They are not repeated in each table
 | `tags` | `TagItemProps[]` | ✓ | Array of tag items to display |
 | `label` | `string` |  | Text to display as the field label |
 | `align` | `SAILAlign` |  | Determines alignment of tags |
-| `size` | `TagSize` |  | Size of the tags |
+| `size` | `Extract(SAILSize, SMALL / STANDARD)` |  | Size of the tags |
 
 ### TagItem
 
@@ -462,11 +462,11 @@ Most components accept these optional props. They are not repeated in each table
 | `validations` | `string[]` |  | Validation errors to display below the field when the value is not null |
 | `saveInto` | `(value: string) => void` |  | Callback when the user changes the text |
 | `onChange` | `(value: string) => void` |  | Callback when the user changes the text (React-style alias for saveInto) |
-| `refreshAfter` | `RefreshAfter` |  | Determines when the interface is refreshed with the saved value |
-| `align` | `TextAlign` |  | Determines alignment of the text value |
+| `refreshAfter` | `KEYPRESS / UNFOCUS` |  | Determines when the interface is refreshed with the saved value |
+| `align` | `LEFT / CENTER / RIGHT` |  | Determines alignment of the text value |
 | `placeholder` | `string` |  | Text to display in the field when it is empty |
 | `masked` | `boolean` |  | Determines if the value is obscured from view (password field) |
-| `inputPurpose` | `InputPurpose` |  | Indicates the intent of input for accessibility improvements |
+| `inputPurpose` | `NAME / EMAIL / PHONE_NUMBER / STREET_ADDRESS / POSTAL_CODE / COUNTRY / CREDIT_CARD_NUMBER / FIRST_NAME / LAST_NAME / DOB / OFF` |  | Indicates the intent of input for accessibility improvements |
 | `characterLimit` | `number` |  | Determines the maximum number of characters |
 | `showCharacterCount` | `boolean` |  | Determines if the character count displays on the text field |
 
@@ -475,11 +475,11 @@ Most components accept these optional props. They are not repeated in each table
 | Prop | Type | Req | Description |
 |------|------|:---:|-------------|
 | `text` | `string / ReactNode / (string / ReactNode)[]` | ✓ | Array of text to display as a rich text item |
-| `style` | `TextStyle / TextStyle[]` |  | Text style(s) to apply. Multiple styles may be applied |
+| `style` | `PLAIN / EMPHASIS / STRONG / UNDERLINE / STRIKETHROUGH / PLAIN / EMPHASIS / STRONG / UNDERLINE / STRIKETHROUGH[]` |  | Text style(s) to apply. Multiple styles may be applied |
 | `size` | `SAILSizeExtended` |  | Text size |
 | `color` | `SAILColorInput` |  | Text color - semantic color, palette token (e.g. TEAL_700), or hex value |
 | `link` | `function` |  | Link to apply to the text |
-| `linkStyle` | `LinkStyle` |  | How the link is underlined |
+| `linkStyle` | `INLINE / STANDALONE` |  | How the link is underlined |
 
 ### ToggleField
 
@@ -495,7 +495,7 @@ Most components accept these optional props. They are not repeated in each table
 | `onChange` | `(value: boolean) => void` |  | Callback when the user toggles the button (React-style alias for saveInto) |
 | `size` | `SAILSize` |  | Size of the toggle button |
 | `color` | `ACCENT / POSITIVE / NEGATIVE / SECONDARY / STANDARD / SAILColorInput` |  | Color when toggle is pressed (hex or semantic) |
-| `style` | `ToggleStyle` |  | Determines the button's appearance |
+| `style` | `SOLID / OUTLINE / GHOST` |  | Determines the button's appearance |
 | `icon` | `string` |  | Icon to display in the button |
 | `iconPosition` | `START / END` |  | Position of icon relative to text |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,243 +1,43 @@
 # Sailwind Component Library - Agent Reference
 
-This document provides essential guidance for AI agents (Amazon Q and Kiro) working with the Sailwind React component library for rapid Appian prototyping.
+## Four Non-Negotiable Rules
 
-## Critical Principles
+1. **Import from `@pglevy/sailwind`** — never from `src/components/` or raw HTML when a Sailwind component exists.
+2. **UPPERCASE prop values** — `size="STANDARD"`, not `size="standard"`. Always.
+3. **Lucide icons, not emoji** — `import { CheckCircle } from 'lucide-react'`, never `✅` or `📄`.
+4. **Data in `src/db/`** — all prototype data as typed async functions. Never inline in components.
 
-### 1. Sailwind-First Big Picture (MANDATORY)
+## Component & Prop Reference (Steering Files)
 
-**DEFAULT APPROACH FOR ALL UI WORK:** Build with components from `@pglevy/sailwind` first.
+These are auto-generated from the installed package and loaded automatically when editing pages:
 
-- For new pages, clone tasks, and redesigns, start by mapping the interface to available Sailwind components.
-- Use raw HTML/Tailwind primitives only for parts the package truly does not support.
-- If raw HTML is used, explicitly state why the package component was not sufficient.
-- `src/components/` is for project-specific custom components only when a package component does not exist.
+- **`.kiro/steering/sail-components.md`** — canonical list of all available components and exact names
+- **`.kiro/steering/sail-props.md`** — full prop tables for every component (use this to avoid guessing)
+- **`.kiro/steering/sail-types.md`** — all SAIL enum types and valid values
 
-**Clone behavior:** If asked to "clone" an existing page/app, reproduce structure and behavior using Sailwind components rather than copying raw DOM structure.
+If these seem stale: `node scripts/sync-sailwind-components.js` and `node scripts/sync-sailwind-props.js`
 
-### 2. SAIL-Exact Parameters (UPPERCASE Required)
+## Data Layer Convention
 
-Always use UPPERCASE for SAIL parameter values:
+All prototype data MUST live in `src/db/` as typed async functions. See `.kiro/steering/data-layer.md` for the full convention.
 
 ```tsx
 // ✅ CORRECT
-<TagField size="STANDARD" labelPosition="COLLAPSED" />
-
-// ❌ WRONG
-<TagField size="standard" labelPosition="collapsed" />
-```
-
-### 3. Import from Sailwind Package First
-
-**PRIMARY SOURCE: Import components from the `@pglevy/sailwind` npm package.**
-
-```tsx
-// ✅ CORRECT - Import from npm package
-import { HeadingField, CardLayout, ButtonWidget } from '@pglevy/sailwind'
-
-// ❌ WRONG - Don't look in src/components first
-import { HeadingField } from '../components'
-```
-
-**Component discovery order:**
-1. **FIRST**: Check `.kiro/steering/sail-components.md` (canonical, auto-synced from installed package exports)
-2. **SECOND**: If needed, verify in `node_modules/@pglevy/sailwind/dist/components/` type definitions
-3. **THIRD**: Only if component doesn't exist in package, consider creating custom component in `src/components/`
-4. **LAST**: Raw HTML/third-party libraries (only when absolutely necessary)
-
-**Note:** `src/components/` is for project-specific custom components only. Most components come from the package.
-
-### 4. Use Lucide Icons (NOT Emoji)
-
-**CRITICAL:** Always use Lucide React icons for visual indicators, NOT emoji characters.
-
-```tsx
-// ✅ CORRECT - Use Lucide icons
-import { CheckCircle, AlertCircle, FileText } from 'lucide-react'
-
-<Icon icon={CheckCircle} color="POSITIVE" size="MEDIUM" />
-
-// ❌ WRONG - Don't use emoji
-<span>✅</span>
-<div>📄</div>
-```
-
-**Why Lucide:**
-- Professional, consistent design system
-- Accessible with proper ARIA attributes
-- Scalable and customizable
-- Matches Appian's design language
-
-**Common Lucide icons:**
-- Status: `CheckCircle`, `XCircle`, `AlertCircle`, `Info`
-- Actions: `Plus`, `Minus`, `Edit`, `Trash2`, `Download`, `Upload`
-- Navigation: `ChevronRight`, `ChevronDown`, `ArrowLeft`, `ArrowRight`
-- Files: `FileText`, `File`, `Folder`, `Image`
-- UI: `Search`, `Filter`, `Settings`, `Menu`, `X`
-
-**Import from:** `lucide-react` (already installed in this project)
-
-### 5. UserImage is NOT a Component
-
-**CRITICAL:** `UserImage` is a data structure, not a React component.
-
-```tsx
-// ❌ WRONG - UserImage is not a component
-<UserImage name="John" imageUrl="/avatar.jpg" size="SMALL" />
-
-// ✅ CORRECT - Use ImageField with style="AVATAR"
-<ImageField
-  images={[{
-    imageType: 'user' as const,
-    user: {
-      name: "John Smith",
-      photoUrl: "/avatar.jpg",
-      initials: "JS"
-    },
-    altText: "John Smith"
-  }]}
-  style="AVATAR"
-  size="SMALL"
-  marginBelow="NONE"
-/>
-```
-
-## Styling Reference
-
-### Text Sizes
-- `SMALL` → `text-xs` (12px)
-- `STANDARD` → `text-base` (16px)
-- `MEDIUM` → `text-lg` (18px)
-- `LARGE` → `text-2xl` (24px)
-
-### Spacing
-- `NONE` → `p-0`, `m-0` (0)
-- `EVEN_LESS` → `p-1`, `m-1` (4px)
-- `LESS` → `p-2`, `m-2` (8px)
-- `STANDARD` → `p-4`, `m-4` (16px)
-- `MORE` → `p-6`, `m-6` (24px)
-- `EVEN_MORE` → `p-8`, `m-8` (32px)
-
-### Shape (Border Radius)
-- `SQUARED` → `rounded-none` (0)
-- `SEMI_ROUNDED` → `rounded-sm` (4px)
-- `ROUNDED` → `rounded-md` (8px)
-
-## Quick Reference Patterns
-
-### Card with Content
-```tsx
-<CardLayout padding="STANDARD" showShadow={true}>
-  <HeadingField text="Title" size="MEDIUM" marginBelow="STANDARD" />
-  <RichTextDisplayField value={["Content here"]} />
-</CardLayout>
-```
-
-### User Avatar
-```tsx
-<ImageField
-  images={[{
-    imageType: 'user' as const,
-    user: {
-      name: user.name,
-      photoUrl: user.imageUrl,
-      initials: user.name?.split(' ').map(n => n[0]).join('').toUpperCase()
-    },
-    altText: user.name
-  }]}
-  style="AVATAR"
-  size="SMALL"
-  marginBelow="NONE"
-/>
-```
-
-### Tags
-```tsx
-<TagField
-  tags={[{ 
-    text: "Status",
-    backgroundColor: "ACCENT"
-  }]}
-  size="SMALL"
-  marginBelow="NONE"
-/>
-```
-
-### Buttons
-```tsx
-<ButtonArrayLayout
-  buttons={[
-    { label: "Save", style: "SOLID", color: "ACCENT" },
-    { label: "Cancel", style: "OUTLINE", color: "SECONDARY" }
-  ]}
-  align="END"
-/>
-```
-
-### Icons (Lucide)
-```tsx
-import { CheckCircle, AlertCircle, FileText } from 'lucide-react'
-
-// Status indicator
-<Icon icon={CheckCircle} color="POSITIVE" size="MEDIUM" />
-
-// With text
-<div className="flex items-center gap-2">
-  <Icon icon={FileText} color="ACCENT" size="SMALL" />
-  <TextItem text="Document.pdf" />
-</div>
-
-// In buttons (if supported by ButtonWidget)
-<ButtonWidget 
-  label="Download"
-  icon={Download}
-  style="OUTLINE"
-  color="SECONDARY"
-/>
-```
-
-## Development Workflow
-
-### Data Layer Convention
-
-**CRITICAL: All prototype data MUST live in `src/db/` as typed async functions.**
-
-- Never inline data directly in page components
-- Each entity gets its own file: `src/db/<entity>.ts` (plural, lowercase)
-- Each file exports: a TypeScript interface, seed data, and async CRUD functions
-- User-reference fields (like `assignee`, `createdBy`) are plain `string` fields containing Appian usernames
-- See `.kiro/steering/data-layer.md` for the full convention and examples
-
-```tsx
-// ✅ CORRECT - Import data from src/db/
 import { getTasks, type Task } from '../db/tasks'
-
 const [tasks, setTasks] = useState<Task[]>([])
 useEffect(() => { getTasks().then(setTasks) }, [])
 
-// ❌ WRONG - Inline data in components
+// ❌ WRONG
 const tasks = [{ id: 1, title: "Review App", ... }]
 ```
 
-### Appian Skills (in `.kiro/skills/`)
+## Page Development Workflow
 
-| Skill | Purpose |
-|-------|---------|
-| `extract-prototype-contract` | Reads `src/db/`, produces `appian-output/api-contract.json` |
-| `generate-appian-app` | Takes contract, produces importable Appian app ZIP + DDL |
-| `deploy-to-appian` | Deploys the generated package to an Appian environment via the Deployment API |
-| `connect-to-appian` | Rewrites `src/db/` to use real `fetch` calls |
-
-### Page Development (Default Location: `src/pages/`)
-
-**CRITICAL: This is a starter template. Components come from the npm package.**
-
-1. **Import from `@pglevy/sailwind` package** - All standard components are available here
-2. **Use EXACT component names** from the Available Components list below (case-sensitive!)
-3. **ONLY create custom components** in `src/components/` if truly needed for project-specific needs
-4. **Add page to routes** in `src/App.tsx`
-5. **Add page link to Home page** in `src/pages/home.tsx` - Add entry to the `pages` array
-6. **REQUIRED: Run `npm run build` and fix all errors before declaring completion**
+1. Create file in `src/pages/`
+2. Import components from `@pglevy/sailwind`
+3. Add route to `src/App.tsx`
+4. Add entry to `pages` array in `src/pages/home.tsx`
+5. Run `pnpm run build` — fix all errors before declaring done
 
 ### Standard Page Structure
 ```tsx
@@ -247,14 +47,9 @@ export default function PageName() {
   return (
     <div className="min-h-screen bg-blue-50">
       <div className="container mx-auto px-8 py-8">
-        <HeadingField
-          text="Page Title"
-          size="LARGE"
-          headingTag="H1"
-          marginBelow="MORE"
-        />
+        <HeadingField text="Page Title" size="LARGE" headingTag="H1" marginBelow="MORE" />
         <CardLayout padding="MORE" showShadow={true}>
-          {/* Compose existing Sailwind components here */}
+          {/* Sailwind components here */}
         </CardLayout>
       </div>
     </div>
@@ -262,103 +57,20 @@ export default function PageName() {
 }
 ```
 
-### Available Sailwind Components (Canonical Source)
+## Appian Skills (in `.kiro/skills/`)
 
-**Do not maintain a manual component list in this file.**
-
-Use `.kiro/steering/sail-components.md` as the source of truth for available components and exact names.
-
-- That file is auto-generated from installed package exports by `scripts/sync-sailwind-components.js`
-- It is triggered by `scripts/check-sailwind-update.js` (via `npm run dev` / predev workflow)
-- If component guidance seems stale, run: `node scripts/sync-sailwind-components.js`
-
-**For complete API details, see:** https://github.com/pglevy/sailwind
-
-### Adding Links to Home Page
-
-**IMPORTANT:** After creating a new page, add it to the Home page for easy navigation.
-
-In `src/pages/home.tsx`, add an entry to the `pages` array:
-
-```tsx
-const pages = [
-  { title: 'Task Dashboard', path: '/task-dashboard', description: 'Example task management interface' },
-  { title: 'Application Status', path: '/application-status', description: 'Application tracking with milestones' },
-  { title: 'Document Review', path: '/document-review', description: 'Document approval workflow' },
-  // Add your new page here:
-  { title: 'Your Page Name', path: '/your-route', description: 'Brief description of your page' },
-]
-```
-
-This allows users to easily navigate to your new page from the home screen.
-
-### Error Resolution Pattern
-
-When encountering "Module has no exported member" errors:
-
-1. **FIRST: Check component name** - Compare against exact names in `.kiro/steering/sail-components.md` (canonical source)
-2. Verify you're importing from `@pglevy/sailwind` (not `../components`)
-3. Check the component name spelling and capitalization (case-sensitive!)
-4. Check if it's a data structure (like `UserImage`) vs a component
-5. Use alternative components (like `ImageField` for avatars)
-6. Consult TypeScript definitions in `node_modules/@pglevy/sailwind/dist/components/`
-
-## Common Mistakes to Avoid
-
-1. ❌ Looking in `src/components/` for Sailwind components (they're in the npm package!)
-2. ❌ Importing from `../components` instead of `@pglevy/sailwind`
-3. ❌ Using wrong component names (e.g., `TextFieldInput` instead of `TextField`)
-4. ❌ Importing `UserImage` as a component (it's a data structure)
-5. ❌ Using lowercase SAIL parameter values
-6. ❌ Using raw HTML when Sailwind component exists in the package
-7. ❌ Using emoji characters (✅❌📄) instead of Lucide icons
-8. ❌ Using color steps other than those defined in the tokens file (`node_modules/@pglevy/sailwind/dist/tokens.json`)
-9. ❌ Forgetting to add the page link to `src/pages/home.tsx`
-
-## Component vs Page Development
-
-### Default Workflow: Page Development (Pragmatic Prototyping)
-**This is the PRIMARY use case for this starter template.**
-
-- Import components from `@pglevy/sailwind` npm package
-- Compose interfaces from existing Sailwind components
-- Create pages in `src/pages/`
-- Add routes to `src/App.tsx`
-
-### Advanced Workflow: Custom Component Development (Only When Needed)
-**ONLY create custom components when Sailwind package doesn't have what you need.**
-
-- Create in `src/components/` directory (you may need to create this directory)
-- MUST use exact SAIL parameter names (UPPERCASE)
-- Export from `src/components/index.ts`
-- Import in pages as needed
-- Document why custom component was necessary
-- Include SAIL translation examples if applicable
-
-## Resources
-
-- **Sailwind Package:** `@pglevy/sailwind` (imported in this project)
-- **Sailwind Repo:** https://github.com/pglevy/sailwind
-- **SAIL Official Docs:** https://docs.appian.com/suite/help/25.3/
-- **Tailwind CSS:** https://tailwindcss.com/
-
-## Success Criteria
-
-- ✅ Components imported from `@pglevy/sailwind` package
-- ✅ Components use exact SAIL parameter names and values (UPPERCASE)
-- ✅ Existing Sailwind components used wherever available from the package
-- ✅ Pages added to routes in `src/App.tsx`
-- ✅ Visual testing passes without errors
-- ✅ Consistent Sailwind token color palette usage
+| Skill | Purpose |
+|-------|---------|
+| `extract-prototype-contract` | Reads `src/db/`, produces `appian-output/api-contract.json` |
+| `generate-appian-app` | Takes contract, produces importable Appian app ZIP + DDL |
+| `deploy-to-appian` | Deploys the generated package to an Appian environment |
+| `connect-to-appian` | Rewrites `src/db/` to use real `fetch` calls |
 
 ## Before Declaring Page Complete
 
-Use this checklist for EVERY page you create:
-
-- [ ] Page file created in `src/pages/`
-- [ ] All imports are from `@pglevy/sailwind` package
-- [ ] **Component names verified against `.kiro/steering/sail-components.md`**
-- [ ] All SAIL parameters use UPPERCASE values
+- [ ] All imports from `@pglevy/sailwind`
+- [ ] Component names verified against `.kiro/steering/sail-components.md`
+- [ ] All SAIL prop values UPPERCASE
 - [ ] Page added to routes in `src/App.tsx`
-- [ ] **Page link added to `src/pages/home.tsx` in the `pages` array**
-- [ ] Dev server shows page loading without console errors
+- [ ] Page link added to `src/pages/home.tsx`
+- [ ] `pnpm run build` passes with no errors

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,10 @@ const tasks = [{ id: 1, title: "Review App", ... }]
 4. Add entry to `pages` array in `src/pages/home.tsx`
 5. Run `pnpm run build` — fix all errors before declaring done
 
-### Standard Page Structure
+### Basic Page Structure
+
+Adjust as needed:
+
 ```tsx
 import { HeadingField, CardLayout } from '@pglevy/sailwind'
 

--- a/scripts/check-sailwind-update.js
+++ b/scripts/check-sailwind-update.js
@@ -108,3 +108,14 @@ try {
 } catch {
   // Silently ignore
 }
+
+// --- Sync steering file props with package ---
+
+try {
+  execSync('node scripts/sync-sailwind-props.js', {
+    encoding: 'utf-8',
+    stdio: 'inherit',
+  })
+} catch {
+  // Silently ignore
+}

--- a/scripts/sync-sailwind-components.js
+++ b/scripts/sync-sailwind-components.js
@@ -95,6 +95,7 @@ Common name mistakes to avoid:
 - ❌ \`Heading\` → ✅ \`HeadingField\`
 - ❌ \`Tabs\` → ✅ \`TabsField\`
 - ❌ \`Tag\` → ✅ \`TagField\`
+- ❌ \`<UserImage />\` → ✅ \`<ImageField style="AVATAR" images={[{ imageType: 'user' as const, ... }]} />\`
 `
 
   writeFileSync(STEERING_PATH, content)

--- a/scripts/sync-sailwind-props.js
+++ b/scripts/sync-sailwind-props.js
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+
+/**
+ * Generates a compact prop reference for all Sailwind components.
+ * Parses .d.ts files from the installed package and writes
+ * .kiro/steering/sail-props.md with a table per component.
+ *
+ * Called by the predev script automatically.
+ */
+
+import { readFileSync, writeFileSync, readdirSync, existsSync } from 'fs'
+import { resolve } from 'path'
+
+const STEERING_PATH = resolve('.kiro/steering/sail-props.md')
+const COMPONENTS_DIR = resolve('node_modules/@pglevy/sailwind/dist/components')
+
+/**
+ * Extract the JSDoc comment immediately before a line.
+ * Returns the comment text stripped of /** and * / markers.
+ */
+function extractJsDoc(lines, lineIndex) {
+  let i = lineIndex - 1
+  while (i >= 0 && lines[i].trim() === '') i--
+  if (i < 0 || !lines[i].trim().endsWith('*/')) return ''
+  const commentLines = []
+  while (i >= 0 && !lines[i].trim().startsWith('/**')) {
+    commentLines.unshift(lines[i].trim().replace(/^\* ?/, ''))
+    i--
+  }
+  if (i >= 0) commentLines.unshift(lines[i].trim().replace(/^\/\*\* ?/, '').replace(/ ?\*\/$/, ''))
+  return commentLines.join(' ').trim()
+}
+
+/**
+ * Parse a single .d.ts file and return an array of prop objects.
+ * Looks for the first `export interface *Props { ... }` block.
+ */
+function parseProps(filePath) {
+  const content = readFileSync(filePath, 'utf-8')
+  const lines = content.split('\n')
+
+  // Find the Props interface
+  const ifaceStart = lines.findIndex(l => /export interface \w+Props/.test(l))
+  if (ifaceStart === -1) return []
+
+  const props = []
+  let depth = 0
+  let inIface = false
+
+  for (let i = ifaceStart; i < lines.length; i++) {
+    const line = lines[i]
+
+    // Track brace depth, but count opens/closes on this line
+    const opens = (line.match(/{/g) || []).length
+    const closes = (line.match(/}/g) || []).length
+
+    if (!inIface) {
+      depth += opens
+      inIface = true
+      continue
+    }
+
+    // Only match props at the top level of the interface (depth 1)
+    if (depth === 1) {
+      // Match prop lines: propName?: type or propName: type
+      const match = line.match(/^\s+(\w+)(\??):\s+(.+?);?\s*$/)
+      if (match) {
+        const [, name, optional, rawType] = match
+        const required = optional !== '?'
+        const type = rawType
+          .replace(/React\.ReactNode/g, 'ReactNode')
+          .replace(/\(\) => void/g, 'function')
+          .replace(/\(value\?: any\) => void/g, 'function')
+          .replace(/React\.FC<\w+>/g, 'component')
+          .trim()
+
+        // For complex inline types (Array<{...}>), simplify to the outer type
+        const simplified = type.replace(/Array<\{$/, 'Array<object>')
+          .replace(/Record<([^>]+)>/g, 'Record')
+
+        const doc = extractJsDoc(lines, i)
+
+        props.push({ name, required, type: simplified, doc })
+      }
+    }
+
+    depth += opens - closes
+    if (depth === 0) break
+  }
+
+  return props
+}
+
+// Props that appear on nearly every component — listed once at the top, omitted from tables
+const COMMON_PROPS = new Set([
+  'className', 'showWhen', 'marginAbove', 'marginBelow',
+  'accessibilityText', 'labelPosition', 'helpTooltip',
+  'validationGroup', 'requiredMessage', 'instructions',
+])
+
+/**
+ * Format props as a compact markdown table, omitting common props.
+ */
+function propsToTable(props) {
+  const filtered = props.filter(p => !COMMON_PROPS.has(p.name))
+  if (filtered.length === 0) return '_No unique props_\n'
+  const rows = filtered.map(p => {
+    const req = p.required ? '✓' : ''
+    // Clean up types for markdown table safety:
+    // - Remove quotes from union types, use / instead of |
+    // - Replace < > with ( ) to avoid markdown HTML parsing
+    // - Fix => arrows that got mangled by the ) replacement
+    const type = p.type
+      .replace(/"/g, '')
+      .replace(/ \| /g, ' / ')
+      .replace(/\|/g, '/')
+      .replace(/</g, '(')
+      .replace(/>/g, ')')
+      .replace(/=\) /g, '=> ')
+    const doc = p.doc.replace(/\|/g, '\\|')
+    return `| \`${p.name}\` | \`${type}\` | ${req} | ${doc} |`
+  })
+  return [
+    '| Prop | Type | Req | Description |',
+    '|------|------|:---:|-------------|',
+    ...rows,
+  ].join('\n') + '\n'
+}
+
+try {
+  const entries = readdirSync(COMPONENTS_DIR, { withFileTypes: true })
+
+  // Map component name → props by scanning each folder's .d.ts files
+  const components = {}
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue
+    const dir = resolve(COMPONENTS_DIR, entry.name)
+    const dtsFiles = readdirSync(dir).filter(f => f.endsWith('.d.ts') && !f.includes('stories') && f !== 'index.d.ts')
+
+    for (const file of dtsFiles) {
+      // Only process files that export a component (PascalCase, not base/internal)
+      if (file.includes('Base') || file.includes('assets')) continue
+      const componentName = file.replace('.d.ts', '')
+      if (!/^[A-Z]/.test(componentName)) continue
+
+      const props = parseProps(resolve(dir, file))
+      if (props.length > 0) {
+        components[componentName] = props
+      }
+    }
+  }
+
+  const sorted = Object.keys(components).sort()
+
+  // Check if update needed
+  let current = ''
+  try { current = readFileSync(STEERING_PATH, 'utf-8') } catch { /* new file */ }
+  if (current.includes(`**${sorted.length} components**`) && sorted.every(n => current.includes(`### ${n}`))) {
+    process.exit(0)
+  }
+
+  const sections = sorted.map(name => {
+    return `### ${name}\n\n${propsToTable(components[name])}`
+  }).join('\n')
+
+  const output = `---
+inclusion: fileMatch
+fileMatchPattern: "src/pages/**"
+---
+
+# Sailwind Component Props Reference
+
+All props for every Sailwind component, parsed from the installed package. Use exact prop names and values — do not guess.
+
+**${sorted.length} components** | All prop values must be UPPERCASE where the type is a SAIL enum.
+
+## Common Props (omitted from tables below)
+
+Most components accept these optional props. They are not repeated in each table:
+
+| Prop | Type | Description |
+|------|------|-------------|
+| \`className\` | \`string\` | Additional Tailwind classes for prototype-specific styling (not part of SAIL API) |
+| \`showWhen\` | \`boolean\` | Controls component visibility |
+| \`marginAbove\` | \`SAILMarginSize\` | Space added above component |
+| \`marginBelow\` | \`SAILMarginSize\` | Space added below component |
+| \`accessibilityText\` | \`string\` | Additional text for screen readers |
+| \`labelPosition\` | \`SAILLabelPosition\` | Where the label appears (ABOVE / ADJACENT / COLLAPSED / JUSTIFIED) |
+| \`helpTooltip\` | \`string\` | Displays a help icon with tooltip text |
+| \`instructions\` | \`string\` | Supplemental text about this field |
+| \`validationGroup\` | \`string\` | Validation group name (no spaces) |
+| \`requiredMessage\` | \`string\` | Custom message when required and not provided |
+
+${sections}`
+
+  writeFileSync(STEERING_PATH, output)
+  console.log(`  ✅ Updated .kiro/steering/sail-props.md with props for ${sorted.length} components.`)
+} catch (err) {
+  // Silently ignore — don't block anything
+}

--- a/scripts/sync-sailwind-props.js
+++ b/scripts/sync-sailwind-props.js
@@ -34,10 +34,19 @@ function extractJsDoc(lines, lineIndex) {
 /**
  * Parse a single .d.ts file and return an array of prop objects.
  * Looks for the first `export interface *Props { ... }` block.
+ * Resolves local type aliases (e.g. type ButtonStyle = "SOLID" | "OUTLINE")
+ * so the prop table shows concrete values instead of alias names.
  */
 function parseProps(filePath) {
   const content = readFileSync(filePath, 'utf-8')
   const lines = content.split('\n')
+
+  // Collect local type aliases: type Name = "A" | "B" | ...
+  const typeAliases = {}
+  for (const line of lines) {
+    const m = line.match(/^type (\w+) = (.+);$/)
+    if (m) typeAliases[m[1]] = m[2]
+  }
 
   // Find the Props interface
   const ifaceStart = lines.findIndex(l => /export interface \w+Props/.test(l))
@@ -67,7 +76,7 @@ function parseProps(filePath) {
       if (match) {
         const [, name, optional, rawType] = match
         const required = optional !== '?'
-        const type = rawType
+        let type = rawType
           .replace(/React\.ReactNode/g, 'ReactNode')
           .replace(/\(\) => void/g, 'function')
           .replace(/\(value\?: any\) => void/g, 'function')
@@ -75,12 +84,19 @@ function parseProps(filePath) {
           .trim()
 
         // For complex inline types (Array<{...}>), simplify to the outer type
-        const simplified = type.replace(/Array<\{$/, 'Array<object>')
+        type = type.replace(/Array<\{$/, 'Array(object)')
           .replace(/Record<([^>]+)>/g, 'Record')
+
+        // Resolve local type aliases to their concrete values
+        if (typeAliases[type]) {
+          type = typeAliases[type]
+        }
+        // Also resolve union types that reference an alias: e.g. "ButtonStyle | string"
+        type = type.replace(/\b(\w+)\b/g, (match) => typeAliases[match] || match)
 
         const doc = extractJsDoc(lines, i)
 
-        props.push({ name, required, type: simplified, doc })
+        props.push({ name, required, type, doc })
       }
     }
 


### PR DESCRIPTION
Optimizes the agent context for better results with smaller/faster models like Haiku, while also benefiting Sonnet.

## Changes

- **New: sail-props.md steering file** — auto-generated prop tables for all 34 components with resolved type values (no more ChoiceLayout → now shows STACKED / COMPACT)
- **New: sync-sailwind-props.js** — parses .d.ts files from the installed package, runs on `pnpm run dev`
- **Trimmed AGENTS.md** — ~300 lines → ~75 lines, removed content now covered by steering files
- **Updated sailor agent prompt** — 4 non-negotiable rules stated upfront before resources load
- **Moved UserImage gotcha** into sail-components.md (single source of truth)
- **git.md** set to manual inclusion (was always-on, wasting context on non-git tasks)
- **MCP settings** — disabled playwright by default

## Why

Smaller models lose instructions as context fills up. These changes front-load the critical rules and provide structured prop references so the model doesn't need to guess or search node_modules.