### PR TITLE
Add Share Link skill and vite allowedHosts config

### DIFF
--- a/.kiro/skills/share-link.md
+++ b/.kiro/skills/share-link.md
@@ -1,0 +1,93 @@
+---
+name: Share Link
+description: >
+  Share your local dev server with others via a public URL using Cloudflare's free quick tunnel service.
+  Creates a temporary public link to your localhost so teammates or stakeholders can preview your prototype
+  without deploying. Use this skill when the user says "share my prototype", "get a public link",
+  "share my local dev", "create a share link", or "let someone else see what I'm working on".
+---
+
+# Share Link
+
+Create a temporary public URL that tunnels to your local dev server using Cloudflare's free `cloudflared` quick tunnel.
+
+## When to Use
+
+- Sharing a prototype with a teammate or stakeholder for quick feedback
+- Demoing work-in-progress without deploying
+- Testing on a mobile device from a different network
+- Any time someone needs to see what's running on your localhost
+
+## Prerequisites
+
+- Local dev server already running (typically `pnpm run dev` on port 5173)
+- Internet connection
+- `npx` available (comes with Node.js)
+
+> **Note:** `vite.config.ts` already includes `server.allowedHosts: ['.trycloudflare.com']`, so Vite will accept requests from any `*.trycloudflare.com` tunnel URL without extra configuration.
+
+## Instructions
+
+### Step 1 — Confirm the dev server is running
+
+Ask the user if their dev server is already running. If not, remind them to start it:
+
+```bash
+pnpm run dev
+```
+
+The default port is `5173`. If they're using a different port, note it for Step 2.
+
+### Step 2 — Start the tunnel
+
+In a **separate terminal window**, run:
+
+```bash
+npx cloudflared tunnel --url http://localhost:5173
+```
+
+- If this is the first time running it, the user will be prompted to confirm installation of the `cloudflared` package — they should accept.
+- Replace `5173` with the actual port if different.
+
+### Step 3 — Find the public URL
+
+The command produces a lot of output. Look for a line like:
+
+```
+Your quick Tunnel has been created! Visit it at (it may take some time to be reachable):
+https://some-random-words.trycloudflare.com
+```
+
+That `https://*.trycloudflare.com` URL is the shareable link. Copy it and send it to whoever needs to see the prototype.
+
+### Step 4 — Share the link
+
+Give the URL to the user and remind them:
+
+- The link is **publicly accessible** — anyone with the URL can view the site
+- It stays active as long as the `cloudflared` process is running in the terminal
+- To stop sharing, press `Ctrl+C` in the terminal running cloudflared
+- The URL is randomly generated and changes each time you restart the tunnel
+
+## Important Caveats
+
+- **Free tier, not production-grade** — this is Cloudflare's complimentary quick tunnel service. It's great for demos and feedback, not for serving real users.
+- **Temporary** — the URL expires when you stop the process. There's no persistence.
+- **Performance** — latency may be higher than localhost since traffic routes through Cloudflare's network.
+- **No auth** — anyone with the link can access your local server. Don't share sensitive data.
+- **200 concurrent request limit** — the tunnel can handle up to 200 requests being processed at the exact same moment. In practice this means roughly 200 people actively clicking around at once — well beyond what a prototype demo needs. If you somehow hit it, visitors will see an error until traffic drops back down.
+- **No real-time/streaming support** — quick tunnels don't support Server-Sent Events (SSE). If the app uses live-updating features (like a real-time feed or streaming AI responses), those won't work through the tunnel.
+
+## Troubleshooting
+
+| Problem | Solution |
+|---|---|
+| "command not found: npx" | Node.js isn't installed or not in PATH. Run the `setup-environment` skill. |
+| Tunnel starts but URL isn't reachable | Wait 10–15 seconds. Quick tunnels can take a moment to propagate. |
+| Connection refused errors | Make sure your dev server is actually running on the specified port. |
+| Tunnel disconnects frequently | Check your internet connection. Restart the tunnel if needed. |
+| Need a stable URL that doesn't change | This free service doesn't support that. Consider deploying to Vercel or GitLab Pages instead. |
+
+## Reference
+
+- Cloudflare docs: https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/do-more-with-tunnels/trycloudflare/

--- a/README.md
+++ b/README.md
@@ -247,30 +247,23 @@ kiro-cli --agent sailor
 
 ### For Kiro IDE Users
 
-**Development Environment Setup**
-- **Skill**: [pnpm-setup](https://github.com/pglevy/agent-skills) - Guided pnpm installation and migration (grab from the agent-skills repo and add to `.kiro/skills/`)
-- **Steering file**: `.kiro/steering/SETUP.md` - Detailed setup guidance available on request
-- **Kiro Power**: `.kiro/powers/setup/POWER.md` - Automated setup assistant (install from Powers panel)
+Skills live in `.kiro/skills/` and are invoked by telling Kiro what you want to do. No installation needed — they're already in the project.
 
-**Vercel Deployment**
-- **Kiro Power**: `.kiro/powers/vercel/POWER.md` - Complete guide for deploying prototypes to Vercel
-- Covers account setup, GitHub/GitLab integration, CLI usage, and secure preview sharing
-- Includes Deployment Protection and Shareable Links for controlled access
-
-**Upgrade Tooling from Template**
-- **Kiro Power**: `.kiro/powers/upgrade/POWER.md` - Syncs your project with the latest scripts, hooks, and steering files from the template repo
-- Fetches files directly from GitHub and compares against your local project
-- Suggests AGENTS.md sections that can be trimmed now that hooks and steering handle them
+| Skill | What it does |
+|-------|-------------|
+| **Setup Environment** | Checks for and installs Homebrew, nvm, Node.js, and pnpm, then gets the dev server running. Good for first-time setup or "command not found" errors. |
+| **Share Link** | Creates a temporary public URL to your local dev server using Cloudflare's free tunnel service — no deployment needed. |
+| **Upgrade from Template** | Syncs your project with the latest scripts, hooks, and steering files from the template repo by fetching directly from GitHub. |
+| **Extract Prototype Contract** | Reads `src/db/` and produces an `api-contract.json` describing the data model — the first step toward generating an Appian app. |
+| **Generate Appian App** | Takes the API contract and produces an importable Appian package (record types, web APIs, DDL, and more). |
+| **Deploy to Appian** | Deploys the generated package to an Appian environment via the Deployment REST API — inspect, import, and poll for results. |
+| **Connect to Appian** | Rewrites `src/db/` to use real `fetch` calls against the generated Appian web APIs. Page components stay unchanged. |
+| **Sailwind Migration** | Full migration for projects not yet on sailwind-starter conventions or old Sailwind versions. |
 
 **Git Workflow Guidance**
-- Designer-friendly git instructions in `.kiro/steering/GIT.md`
+- Designer-friendly git instructions in `.kiro/steering/git.md`
 - Automatically included in context when working with git
 - Helps with branching, commits, and pull requests
-
-**Component Library Reference**
-- `AGENTS.md` - Comprehensive guide for AI assistants
-- Includes component usage patterns, common mistakes, and validation requirements
-- Automatically loaded by the sailor agent
 
 ### For Both Kiro IDE & CLI
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "check:colors": "node scripts/check-color-palette.js"
   },
   "dependencies": {
-    "@pglevy/sailwind": "^0.13.2",
+    "@pglevy/sailwind": "^0.14.0",
     "lucide-react": "^1.8.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@pglevy/sailwind':
-        specifier: ^0.13.2
-        version: 0.13.2(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: ^0.14.0
+        version: 0.14.0(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       lucide-react:
         specifier: ^1.8.0
         version: 1.8.0(react@19.2.0)
@@ -577,8 +577,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@pglevy/sailwind@0.13.2':
-    resolution: {integrity: sha512-+UyQk2oxmK+j3Gh1NFw05aGOMdImFXT7bifIAo91uYSYeD04x8MDgk6SC0yI04BdziY1Guy3MO10n5SPDcCwnA==}
+  '@pglevy/sailwind@0.14.0':
+    resolution: {integrity: sha512-qg1admy1488PeMcDQ7U2CrH8KHLwAaE/URrKMfc19Wc0F1etVnAwVb3pfb88txwarPlY5TT8/UxK++QuJcbARQ==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
@@ -2431,7 +2431,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@pglevy/sailwind@0.13.2(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@pglevy/sailwind@0.14.0(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/react-avatar': 1.1.10(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,4 +5,7 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   base: './',
+  server: {
+    allowedHosts: ['.trycloudflare.com'],
+  },
 })


### PR DESCRIPTION
Closes #21

## Changes

- Adds `.kiro/skills/share-link.md` — a new skill for sharing the local dev server via a public URL using Cloudflare's free quick tunnel
- Adds `server.allowedHosts: ['.trycloudflare.com']` to `vite.config.ts` so tunnel URLs work without manual config changes
- Updates README to replace stale Powers references with a skills table reflecting the current project

## Notes

- Skill name is generic (Share Link) rather than Cloudflare-specific
- Caveats section covers the 200 concurrent request limit, SSE limitation, temporary URL, and no-auth considerations