### PR TITLE
Add deploy script (Appian internal)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,11 @@ Perfect for designers and developers who want to quickly mock up Appian interfac
 
 ## 🚀 Quick Start
 
-### 1. Use This Template
+### 1. Download Template
 
-1. **Click "Use this template" button** on GitHub to create a new repository
-    - *Make it private for internal work!*
-2. **Download your new repository** (or clone if using git)
-3. **Open folder in VS Code** (or preferred IDE)
+[Download a copy](https://github.com/pglevy/sailwind-starter/archive/refs/heads/main.zip) of the template, extract the zip, and open in your preferred code editor.
+
+(We don't recommend GitHub for private repos but if you're working in public, feel free to use the `Use this template` option to create a new GitHub repo based on this template.)
 
 ### 2. Install pnpm
 
@@ -30,8 +29,6 @@ This project uses [pnpm](https://pnpm.io/) as its package manager. If you don't 
 ```bash
 corepack enable
 ```
-
-That's it — corepack reads the `packageManager` field in `package.json` and sets up the right version of pnpm automatically.
 
 Alternatively, install pnpm directly:
 
@@ -60,7 +57,7 @@ pnpm run dev
 Open [http://localhost:5173](http://localhost:5173) to see your prototype!
 
 > [!Tip]
-> Need some extra help getting set up? If you're using Kiro IDE, there's a setup power built in, or you can grab the [pnpm-setup skill](https://github.com/pglevy/agent-skills) for step-by-step guidance. See the [options below](#for-kiro-ide-users) for more details.
+> Need some extra help getting set up? Ask your agent to use the `configure-environment` skill.
 
 ## 🪝 Agent Hooks
 

--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ pnpm run build         # Build for production
 pnpm run preview       # Preview production build
 pnpm run lint          # Lint code
 pnpm run check:colors  # Check for off-palette Tailwind color steps
+pnpm run deploy:site   # Deploy to GitLab site (Appian internal)
 ```
 
 ## 📚 Documentation

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "check:colors": "node scripts/check-color-palette.js"
+    "check:colors": "node scripts/check-color-palette.js",
+    "deploy:site": "bash scripts/deploy-site.sh"
   },
   "dependencies": {
     "@pglevy/sailwind": "^0.15.0",

--- a/scripts/deploy-site.sh
+++ b/scripts/deploy-site.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# deploy-site.sh — Build sailwind-starter, copy to ux-sites repo, and open a merge request
+# Usage: pnpm run deploy:site --site <site-name>
+set -euo pipefail
+
+# --- Parse arguments ---------------------------------------------------------
+SITE_NAME=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --site)
+      SITE_NAME="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1"
+      echo "Usage: $0 --site <site-name>"
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$SITE_NAME" ]]; then
+  echo "Error: --site <site-name> is required."
+  echo "Usage: $0 --site <site-name>"
+  exit 1
+fi
+
+# --- Config ------------------------------------------------------------------
+SITES_REPO="/Users/philip.levy/Documents/GitLab/ux-sites"
+TARGET="$SITES_REPO/sites/$SITE_NAME"
+BRANCH="deploy/$SITE_NAME-$(shuf -i 10000-99999 -n 1)"
+SOURCE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# --- Build -------------------------------------------------------------------
+echo "▸ Building site..."
+cd "$SOURCE_DIR"
+pnpm build
+
+# --- Sync to ux-sites --------------------------------------------------------
+echo "▸ Syncing build to ux-sites/sites/$SITE_NAME..."
+rm -rf "$TARGET"
+cp -r "$SOURCE_DIR/dist" "$TARGET"
+
+# --- Branch, commit, push, MR ------------------------------------------------
+echo "▸ Creating branch and MR..."
+cd "$SITES_REPO"
+git checkout main
+git pull
+git checkout -b "$BRANCH"
+git add "sites/$SITE_NAME"
+git commit -m "Deploy $SITE_NAME site build"
+git push -u origin "$BRANCH"
+glab mr create --fill --yes --target-branch main
+
+echo "✔ Done. MR created on branch: $BRANCH"

--- a/scripts/deploy-site.sh
+++ b/scripts/deploy-site.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# deploy-site.sh — Build sailwind-starter, copy to ux-sites repo, and open a merge request
+# deploy-site.sh — Build sailwind-starter, push to ux-sites repo, and open a merge request
 # Usage: pnpm run deploy:site --site <site-name>
 set -euo pipefail
 
@@ -26,26 +26,32 @@ if [[ -z "$SITE_NAME" ]]; then
 fi
 
 # --- Config ------------------------------------------------------------------
-SITES_REPO="/Users/philip.levy/Documents/GitLab/ux-sites"
-TARGET="$SITES_REPO/sites/$SITE_NAME"
+SITES_REPO_URL="https://gitlab.appian-stratus.com/docs/ux-sites.git"
 BRANCH="deploy/$SITE_NAME-$(shuf -i 10000-99999 -n 1)"
 SOURCE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+
+# Clean up temp dir on exit (success or failure)
+trap 'rm -rf "$TMP_DIR"' EXIT
 
 # --- Build -------------------------------------------------------------------
 echo "▸ Building site..."
 cd "$SOURCE_DIR"
 pnpm build
 
-# --- Sync to ux-sites --------------------------------------------------------
-echo "▸ Syncing build to ux-sites/sites/$SITE_NAME..."
+# --- Clone ux-sites into temp dir --------------------------------------------
+echo "▸ Cloning ux-sites..."
+git clone --depth 1 "$SITES_REPO_URL" "$TMP_DIR/ux-sites"
+
+# --- Sync build to target folder ---------------------------------------------
+TARGET="$TMP_DIR/ux-sites/sites/$SITE_NAME"
+echo "▸ Syncing build to sites/$SITE_NAME..."
 rm -rf "$TARGET"
 cp -r "$SOURCE_DIR/dist" "$TARGET"
 
 # --- Branch, commit, push, MR ------------------------------------------------
 echo "▸ Creating branch and MR..."
-cd "$SITES_REPO"
-git checkout main
-git pull
+cd "$TMP_DIR/ux-sites"
 git checkout -b "$BRANCH"
 git add "sites/$SITE_NAME"
 git commit -m "Deploy $SITE_NAME site build"


### PR DESCRIPTION
- Adds a package script to automatically deploy a build of the site to an internal site for hosting and sharing
- Run `pnpm run deploy:site --site demo-project` (where demo-project is name of folder on target site) to use
- Clone target repo to `tmp` folder to manage git operations from there; removes when done